### PR TITLE
Update settings.js to default DragonOS Whisper.cpp location

### DIFF
--- a/RX/DDC_whisper/settings.js
+++ b/RX/DDC_whisper/settings.js
@@ -1,6 +1,6 @@
 
-//var whisper_path='/usr/src/whisper.cpp/';
-var whisper_path='/home/eric/SDRT/whisper.cpp/';
+var whisper_path='/usr/src/whisper.cpp/';
+//var whisper_path='/home/eric/SDRT/whisper.cpp/';
 
 var whisper_model='ggml-tiny.en.bin';
 


### PR DESCRIPTION
Made small change to reflect default location of Whisper.cpp in DragonOS. It could be anything of course, but seems like a good default. 