### PR TITLE
Enable FM Decoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,4 +231,23 @@ DDCBank examples (2 channels and more) are requiring a registered license.
 - For mobile operation, [capture RF spectrum and log GPS position](./RX/spectrum/GPS) into a CSV file.  
 
 
+## Troubleshooting
 
+### Cannot Open Shared Object Error When Running sdrvm
+
+Example error output:
+
+```
+user@user:~/$ sdrvm
+sdrvm: error while loading shared libraries: libSoapySDR.so.0.8: cannot open shared object file: No such file or directory 
+```
+
+Solution:
+
+```
+sudo find / -name libSoapySDR.so.0.8
+# note the path where the shared object is found. Do not include the actual shared object file in the next command, only its absolute path
+export LD_LIBRARY_PATH=/path/to/shared/object/directory:$LD_LIBRARY_PATH
+```
+
+If you don't have the shared object, you'll likely have to install Soapy: http://sdrvm.sdrtechnologies.fr/releases/#upgrading-soapysdr-to-v08

--- a/RX/DDC_whisper/DDC_MQTT_FM_whisper.js
+++ b/RX/DDC_whisper/DDC_MQTT_FM_whisper.js
@@ -132,7 +132,7 @@ while( fifo_from_rx.isFromRx()) { // if we have something in the input
                 if (recording == 1) {
                     print('End record');
                     IO.fdelete('/tmp/null.cs8');
-                    createTask('FM_demod.js', new_file);
+                    createTask('FM_demod.js', new_file, nbfm_bandwidth);
                 }
                 if (debug) {
                     print(iflevel.toFixed(2), '  *** No signal !  - Trigger : ', trigger.toFixed(2));

--- a/RX/DDC_whisper/DDC_MQTT_FM_whisper.js
+++ b/RX/DDC_whisper/DDC_MQTT_FM_whisper.js
@@ -1,4 +1,4 @@
-
+var counter = 0;
 // Record and NBFM demodulate VHF signal, the pipe it to whisper.cpp
 
 
@@ -59,13 +59,14 @@ if( !rx.isValid()) {
 
 if( rx.isAvailable() ) {
    // set sample rate
-   if( rx.setRxSampleRate( 2e6 )) {
+   if( rx.setRxSampleRate( 2.4e6 )) {
       print('Sample rate changed');
    }
 } else {
    print('device is already used, we do not change Sampling Rate');
 }
 
+print(center_freq)
 rx.setRxCenterFreq( center_freq );
 rx.setGain(rx_gain);
 
@@ -85,6 +86,7 @@ if( !fifo_from_rx.ReadFromRx( rx ) ) {
 var recording=0;
 var slice = new DDC('one');
 slice.setOutBandwidth(16e3); // 16 kHz output
+print(offset_center)
 slice.setCenter( offset_center ) ; // shift frequency from center
 
 print('Listening on ',  (rx.getRxCenterFreq() + (offset_center/1e6)).toFixed(3), ' MHz');
@@ -120,60 +122,46 @@ for (var a=0; a< 20; a++) {
 trigger=(baseline/19)+ threshold;
 print('Baseline level on last 20 blocks :', baseline/19, ' -  set trigger level : ' , trigger );
 
-
 var new_file='';
 print('waiting for signal ...');
-while( fifo_from_rx.isFromRx() ) { // if we have something in the input
-	if( IQBlock.readFromQueue( fifo_from_rx ) ) {	 // load samples from input queue into IQBlock object
-		slice.write( IQBlock );				 // write the samples in the DDC object
-		var ifdata = slice.read();
-//       print( 'Trigger : ', trigger);
-
-       while( ifdata.getLength() > 0 ) {		 // if we have something
-			var iflevel=ifdata.rms();
-		if (use_mqtt) {MBoxPost('rms1', iflevel); }
-			if  (iflevel > trigger ) {
-//                                fifo_to_file.enqueue( ifdata );
-				// ifo_to_file.writeToFile( new_file);
-				if (recording==0) {
-					// create new file based on timestamp
-					var timestamp = new Date().toISOString().replace(/[^\w]/g, "");
-					var date = timestamp.slice(0, -4);
-					var datenow =  date.replace("T", "-") ;
-					new_file = dest_folder + 'F_' + (rx.getRxCenterFreq() + (offset_center/1e6)).toFixed(3) + '_' + datenow + '.cf32';
-					print('New file :',  new_file) ;
-//					ifdata.appendToFile( new_file);
-//					fifo_to_file.enqueue( ifdata );
-//					fifo_to_file.writeToFile( new_file);
-					} 
-//					else {fifo_to_file.enqueue( ifdata );}
-				recording=1;
-		                print(iflevel.toFixed(2),'  *** Recording ... ');
-//				fifo_to_file.enqueue( ifdata );			// write the samples in the output queue
-				ifdata.appendToFile(new_file);
-                                ifdata = slice.read();
-				recording=1;		
-                } else { 
-			if  (recording==1) {
-						print('End record');
-//						Queues.delete( 'output');
-//						fifo_to_file = Queues.create( 'output');
-//						fifo_to_file.stop();
-						IO.fdelete('/tmp/null.cs8');
-//						createTask('start_whisper.js', '/tmp/F_' + (rx.getRxCenterFreq() + (offset_center/1e6)).toFixed(3) + '_' + datenow + '.wav' );
-						createTask('FM_demod.js',new_file);
-						}
-					
-					if (debug) { print(iflevel.toFixed(2),'  *** No signal !  - Trigger : ', trigger.toFixed(2));}
-
-//				fifo_to_null.enqueue( ifdata );                 // write the samples in the output queue
-				ifdata = slice.read();
-				recording=0;
-				}
-       }
-           
-   }
+while( fifo_from_rx.isFromRx()) { // if we have something in the input
+    if( IQBlock.readFromQueue( fifo_from_rx ) ) {   // load samples from input queue into IQBlock object
+        slice.write( IQBlock );                 // write the samples in the DDC object
+        var ifdata = slice.read();
+        while( ifdata.getLength() > 0 ) {         // if we have something
+            var iflevel = ifdata.rms();
+            if (use_mqtt) {
+                MBoxPost('rms1', iflevel);
+            }
+            if (iflevel > trigger && counter < recorder_limit) {
+                if (recording == 0) {
+                    var timestamp = new Date().toISOString().replace(/[^\w]/g, "");
+                    var date = timestamp.slice(0, -4);
+                    var datenow = date.replace("T", "-");
+                    new_file = dest_folder + 'F_' + (rx.getRxCenterFreq() + (offset_center/1e6)).toFixed(3) + '_' + datenow + '.cf32';
+                    print('New file :', new_file);
+                }
+                recording = 1;
+                counter++;
+                print(iflevel.toFixed(2), '  *** Recording ... ', counter);
+                ifdata.appendToFile(new_file);
+                ifdata = slice.read();
+                recording = 1;
+            } else {
+				counter = 0;
+                if (recording == 1) {
+                    print('End record');
+                    IO.fdelete('/tmp/null.cs8');
+                    createTask('FM_demod.js', new_file);
+                }
+                if (debug) {
+                    print(iflevel.toFixed(2), '  *** No signal !  - Trigger : ', trigger.toFixed(2));
+                }
+                ifdata = slice.read();
+                recording = 0;
+            }
+        }
+    }
 }
 
 print('finished!');
-

--- a/RX/DDC_whisper/FM_demod.js
+++ b/RX/DDC_whisper/FM_demod.js
@@ -5,7 +5,7 @@ print('Start FM_DEMOD');
 var whisper_box = new SharedMap('dictionnary_1');
 
 
-var input_samplerate=16000;
+var input_samplerate=16000; //matches line 88 of DDC_MQTT_FM_whisper.js "slice.setOutBandwidth(250e3); // 16 kHz output"
 var output_samplerate=16000;
 
 
@@ -13,7 +13,7 @@ var IQ = new IQData('');
 //var IQ;
 var samples = 0 ;
 var filename=argv(0);
-var SRinput= {'sample_rate' : 16000};
+var SRinput= {'sample_rate' : input_samplerate};
 
 if( !IQ.loadFromFile( filename ) ) {
 //if( !IQ.loadFromFile( filename, SRinput ) ) {

--- a/RX/DDC_whisper/FM_demod.js
+++ b/RX/DDC_whisper/FM_demod.js
@@ -4,16 +4,11 @@ print('Start FM_DEMOD');
 
 var whisper_box = new SharedMap('dictionnary_1');
 
-
-var input_samplerate=16000; //matches line 88 of DDC_MQTT_FM_whisper.js "slice.setOutBandwidth(250e3); // 16 kHz output"
-var output_samplerate=16000;
-
-
 var IQ = new IQData('');
 //var IQ;
 var samples = 0 ;
 var filename=argv(0);
-var SRinput= {'sample_rate' : input_samplerate};
+var SRinput= {'sample_rate' : nbfm_bandwidth};
 
 if( !IQ.loadFromFile( filename ) ) {
 //if( !IQ.loadFromFile( filename, SRinput ) ) {
@@ -23,7 +18,7 @@ if( !IQ.loadFromFile( filename ) ) {
 
 
 // Input file : set samplerate
-IQ.setSampleRate(parseInt(input_samplerate));
+IQ.setSampleRate(parseInt(nbfm_bandwidth));
 //IQ.setCenterFrequency( 100 );
 
 //Input file : display details

--- a/RX/DDC_whisper/FM_demod.js
+++ b/RX/DDC_whisper/FM_demod.js
@@ -7,7 +7,8 @@ var whisper_box = new SharedMap('dictionnary_1');
 var IQ = new IQData('');
 //var IQ;
 var samples = 0 ;
-var filename=argv(0);
+var filename = argv(0);
+var nbfm_bandwidth = argv(1)
 var SRinput= {'sample_rate' : nbfm_bandwidth};
 
 if( !IQ.loadFromFile( filename ) ) {

--- a/RX/DDC_whisper/README.md
+++ b/RX/DDC_whisper/README.md
@@ -121,12 +121,23 @@ F_435.051_20221209-144646.cf32.wav   --> NBFM demodulated audio
 
 ### Testing
 
+**Note**: The FM decoder only works on NarrowBand FM transmissions.
+
+#### Walkie Talkie
+
 - Set your walkie-talkie to 435.050 MHz NFM, with very low power (the minimum).  
 - Launch `DDC_MQTT_FM_whisper.js` script  
 - After the baseline step (define noise floor by taking 20 measurements), send a short transmission by pressing the PTT. Check if you get recording files in /tmp.  
 - If OK, go away from few meters to avoid saturation, press PTT then speak clearly. The best is to start with a short message containing numbers or letters in international code. Then continue with a short sentence.    
-- Wait few seconds to get the result on screen. Decoding may take some time!   
+- Wait few seconds to get the result on screen. Decoding may take some time!
+
+#### Weather Station
+
+1. Find the weather station near you: https://www.weather.gov/nwr/station_search
+2. Note the frequency and configure it in your `settings.json`
+3. Adjust the `recorder_limit` variable in `settings.json` to tune how long you want to capture the weather station before decoding
 
 ## TODO
 
-- [x] publish decoded text to MQTT and then use your MQTT to Kibana to generate a word cloud
+- [x] publish decoded text to MQTT and then use your MQTT to Kibana to generate a word cloud.
+    - See [word cloud in Kibana](#word-cloud-in-kibana) section above for solution

--- a/RX/DDC_whisper/README.md
+++ b/RX/DDC_whisper/README.md
@@ -102,3 +102,7 @@ F_435.051_20221209-144646.cf32.wav   --> NBFM demodulated audio
 - After the baseline step (define noise floor by taking 20 measurements), send a short transmission by pressing the PTT. Check if you get recording files in /tmp.  
 - If OK, go away from few meters to avoid saturation, press PTT then speak clearly. The best is to start with a short message containing numbers or letters in international code. Then continue with a short sentence.    
 - Wait few seconds to get the result on screen. Decoding take some time !   
+
+## TODO
+
+- [ ] publish decoded text to MQTT and then use your MQTT to Kibana to generate a word cloud

--- a/RX/DDC_whisper/README.md
+++ b/RX/DDC_whisper/README.md
@@ -1,37 +1,58 @@
-Example video : [short video](./_demo_DDC_whisper.mp4)
+# DDC Whispher
 
-DragonOS video : [DragonOS FocalX Captured IQ to Text Faster w/ SDR4space/WhisperCPP/Mosquitto (RTLSDR)](https://www.youtube.com/watch?v=oCmFTHm3oX4)  
+[Digital Down Conversion (DDC)](https://en.wikipedia.org/wiki/Digital_down_converter) integrated with [OpenAI's Whispher](https://github.com/openai/whisper) speech recognition model for [Amplitude Modulated (AM)](https://en.wikipedia.org/wiki/Amplitude_modulation) and [Frequency Modulated (FM)](https://en.wikipedia.org/wiki/Frequency_modulation) signals.
+
+Example video of FM voice-to-text: [short video](./_demo_DDC_whisper.mp4)
+
+DragonOS video demonstration: [DragonOS FocalX Captured IQ to Text Faster w/ SDR4space/WhisperCPP/Mosquitto (RTLSDR)](https://www.youtube.com/watch?v=oCmFTHm3oX4)  
 
 Thanks to [@paulzcgu](https://github.com/paulzcgu) for [writing a set of scripts](https://github.com/paulzcgu/sdr_multi_producer) based on this example, managing several SDR on a RPi4 running DragonOS  
 (tnx for this info @CemaXecuter)
 
-#### Usage   
+## Usage   
 
 `/opt/vmbase/sdrvm -f DDC_MQTT_FM_whisper.js`  for FM modulation  
+
 `/opt/vmbase/sdrvm -f DDC_MQTT_AM_whisper.js`  for AM modulation  
 
-`/opt/vmbase/sdrvm -f DDC_MQTT_FM_whisper.js --args=156.8` listen on 156.800MHz  
+`/opt/vmbase/sdrvm -f DDC_MQTT_FM_whisper.js --args=156.8` listen on 156.800MHz
+
+## Word Cloud in Kibana
+
+1. Clone the `word-cloud` branch of the [mqtt-to-kibana repository](https://github.com/irongiant33/mqtt-to-kibana/tree/word-cloud) 
+2. Ensure line 7 of `subscriber.py` from the above repository matches line 17 of `start_whisper.js` within the `DDC_whisper` folder
+    - line 7 of `subscriber.py`: `whisper_topic = "SDR/station_1/whisper"`
+    - line 17 of `start_whisper.js`: `'topic': 'SDR/station_1/whisper',`
+3. Ensure the mqtt server address is identical in `subscriber.py` of the above repository and in `settings.js` in `DDC_whisper`
+    - line 6 of `subscriber.py`: `mqtt_broker_address = "0.0.0.0"`
+    - line 41 of `settings.js`: `var mqtt_server = '127.0.0.1';`
+4. Ensure `var use_mqtt = true;` on line 40 of `settings.js`
+5. Start elasticsearch and kibana according to the guide in the mqtt-to-kibana repository.
+6. Start the subscriber: `python3 subscriber.py`
+7. Start `sdrvm` according to the [usage](#usage) instructions above.
 
 ## Initial configuration
 
 ### whisper.cpp  
 
 #### Dragon OS
+
 * Using DragonOS you have nothing to do. whisper.cpp application is installed in /usr/src.  
 
 #### Manual installation
 
 Install as described in the main github page https://github.com/ggerganov/whisper.cpp.  
-Download model tiny.en. Execute from whisper directory : `bash ./models/download-ggml-model.sh tiny.en`  
 
+Download model tiny.en. Execute from whisper directory : `bash ./models/download-ggml-model.sh tiny.en`  
 
 The script is queuing WAV files before transcoding by whisper.cpp to avoid CPU congestion. Files to process are listed in '/tmp/tasks.txt' file.  
 
 ### Prepare settings.js file
+
 * Modify the path to whisper directory in `start_whisper.js` file with a trailing /:  
-  `var whisper_path='/home/$USER/whisper.cpp/';`  
-   Replace $USER by the system username.  
-   The model name is also defined in this file in case you want to test another one (after download).  
+    1. `var whisper_path='/home/$USER/whisper.cpp/';`  
+    2. Replace $USER by the system username.  
+    3. The model name is also defined in this file in case you want to test another one (after download).  
 
 * Set `var use_mqtt = true;` to enable MQTT messaging.  
 * Set `var debug=false;` to get more messages on terminal.  
@@ -70,30 +91,33 @@ var debug=false;   // true/false
 ### DDC_MQTT_XX_whisper.js file
 
 - Adapt the soapy driver :  
-`var rx = Soapy.makeDevice( {'query' : 'driver=rtlsdr'});  
+```javascript
+var rx = Soapy.makeDevice( {'query' : 'driver=rtlsdr'});  
+```
 
 ### MQTT 
 
-Signal level for the channel is sent to MQTT broker on localhost (127.0.0.1).  
+Signal level for the channel is sent to MQTT broker on localhost (`127.0.0.1`).  
 
 As basic test `mosquitto_sub -h 127.0.0.1 -t SDR/station_1/rms` will display received level on terminal.  
+
 Transcoded messages from WAV : `mosquitto_sub -h 127.0.0.1 -t SDR/station_1/whisper`  
 
 #### Using MQTT-Explorer
 
 Left : signal level, number of WAV files in whisper's queue.  
+
 Right : message decoded by whisper.cpp.  
 
 ![mqtt-explorer](mqtt_whisper.jpg)  
 
-
-
 ### Output files :  
 
 F_435.051_20221209-144646.cf32.wav.txt  --> text coming from whisper.cpp for this wav  
-F_435.051_20221209-144646.cf32_audio.png  --> spectrogram of the wav file  
-F_435.051_20221209-144646.cf32.wav   --> NBFM demodulated audio  
 
+F_435.051_20221209-144646.cf32_audio.png  --> spectrogram of the wav file  
+
+F_435.051_20221209-144646.cf32.wav   --> NBFM demodulated audio  
 
 ### Testing
 
@@ -101,8 +125,8 @@ F_435.051_20221209-144646.cf32.wav   --> NBFM demodulated audio
 - Launch `DDC_MQTT_FM_whisper.js` script  
 - After the baseline step (define noise floor by taking 20 measurements), send a short transmission by pressing the PTT. Check if you get recording files in /tmp.  
 - If OK, go away from few meters to avoid saturation, press PTT then speak clearly. The best is to start with a short message containing numbers or letters in international code. Then continue with a short sentence.    
-- Wait few seconds to get the result on screen. Decoding take some time !   
+- Wait few seconds to get the result on screen. Decoding may take some time!   
 
 ## TODO
 
-- [ ] publish decoded text to MQTT and then use your MQTT to Kibana to generate a word cloud
+- [x] publish decoded text to MQTT and then use your MQTT to Kibana to generate a word cloud

--- a/RX/DDC_whisper/settings.js
+++ b/RX/DDC_whisper/settings.js
@@ -37,7 +37,7 @@ var threshold= -5; // trigger level over noise level to start record
 // mosquitto_sub -h <mqtt_server_ip> -t SDR/station_1/rms will display received level on terminal.
 // transcoded messages from WAV : mosquitto_sub -h <mqtt_server_ip> -t SDR/station_1/whisper
 
-var use_mqtt = false;   //  true/false
+var use_mqtt = true;   //  true/false
 var mqtt_server = '127.0.0.1';
 
 

--- a/RX/DDC_whisper/settings.js
+++ b/RX/DDC_whisper/settings.js
@@ -1,8 +1,9 @@
 
-var whisper_path='/usr/src/whisper.cpp/';
+var whisper_path='/home/dev3/Documents/whisper.cpp/';
 //var whisper_path='/home/eric/SDRT/whisper.cpp/';
 
-var whisper_model='ggml-tiny.en.bin';
+var whisper_model='ggml-base.en.bin';
+var recorder_limit = 100
 
 
 // SDR 
@@ -12,7 +13,7 @@ var whisper_model='ggml-tiny.en.bin';
 if (argc()==1) {
 		var listening_frequency=parseFloat(argv(0));
 		} else {
-			var listening_frequency = 435.050;   // MHZ --> adapt
+			var listening_frequency = 162.550;   // MHZ --> adapt
 			//var listening_frequency = 145.700; 
 			}
 
@@ -29,7 +30,7 @@ var offset_center = 250e3; // offset from center,
 var rx_gain=35;
 
 
-var threshold= 5; // trigger level over noise level to start record
+var threshold= -5; // trigger level over noise level to start record
 
 // MQTT
 // Get messages :
@@ -45,4 +46,4 @@ var mqtt_server = '127.0.0.1';
 var dest_folder='/tmp/'
 
 // Add more messages (signal level , whisper stdout + stderr)
-var debug=false;   // true/false
+var debug = false;   // true/false

--- a/RX/DDC_whisper/settings.js
+++ b/RX/DDC_whisper/settings.js
@@ -1,46 +1,32 @@
 
 var whisper_path='/home/dev3/Documents/whisper.cpp/';
-//var whisper_path='/home/eric/SDRT/whisper.cpp/';
-
 var whisper_model='ggml-base.en.bin';
 var recorder_limit = 100
-
-
-// SDR 
+var driver_type = "rtlsdr" // or "bladerf""
 
 // Listening frequency, adapt to the frequency to monitor  : center_freq + offset_center
 
 if (argc()==1) {
-		var listening_frequency=parseFloat(argv(0));
-		} else {
-			var listening_frequency = 162.550;   // MHZ --> adapt
-			//var listening_frequency = 145.700; 
-			}
+	var listening_frequency=parseFloat(argv(0));
+}
+else {
+	var listening_frequency = 162.550;   // MHZ --> adapt
+}
 
 
 // We set a 250kHz shift to avoid the DC center spike.
 var offset_center = 250e3; // offset from center (unit Hz)
 var center_freq = listening_frequency - (offset_center/1e6);
-
-/*
-var center_freq=434.8;
-var offset_center = 250e3; // offset from center, 
-*/
-
 var rx_gain=35;
-
-
 var threshold= -5; // trigger level over noise level to start record
+var nbfm_bandwidth = 16000 // Hz
 
 // MQTT
 // Get messages :
 // mosquitto_sub -h <mqtt_server_ip> -t SDR/station_1/rms will display received level on terminal.
 // transcoded messages from WAV : mosquitto_sub -h <mqtt_server_ip> -t SDR/station_1/whisper
-
 var use_mqtt = true;   //  true/false
 var mqtt_server = '127.0.0.1';
-
-
 
 // destination directory for IQ, WAV and txt files (with trailing /)
 var dest_folder='/tmp/'

--- a/RX/DDC_whisper/test.js
+++ b/RX/DDC_whisper/test.js
@@ -1,0 +1,2 @@
+//createTask('FM_demod.js', "/home/dev3/.config/sdrpp/recordings/baseband_99386000Hz_13-57-20_26-08-2023.wav");
+createTask('start_whisper.js')

--- a/RX/settings.js
+++ b/RX/settings.js
@@ -1,0 +1,44 @@
+// sample rate
+var sample_rate=2e6;
+
+// For specific devices, set RF bandwidth, usually same as samplerate
+//rx.setRxBandwidth(2e6);
+var sdr_bandwidth=2e6;
+
+
+// Define computer hostname
+var hostname="DragonOS";
+
+
+// Define SoapySDR driver name
+var sdr_device='driver=rtlsdr';  
+
+// define default rx_gain
+var rx_gain=45;
+
+// GQRX remote_control
+var gqrx_host='127.0.0.1';
+var gqrx_port=7356;
+
+// MQTT server
+var mqtt_server='127.0.0.1';
+
+
+// InfluxDB/Grafana
+var db_server='127.0.0.1:8086';
+
+
+// Destination folder, add trailing slash, can be empty
+var dest_folder='/tmp/';
+
+
+var default_freq = 100.35;
+
+
+// Define GNUplot path
+var gnuplot_app='/usr/bin/gnuplot';
+
+// SAT - Observer
+var observer_lat=44;
+var observer_lon=-1.2;
+var observer_alt=60;

--- a/RX/spectrum/0_simple_spectrum/settings.js
+++ b/RX/spectrum/0_simple_spectrum/settings.js
@@ -1,0 +1,44 @@
+// sample rate
+var sample_rate=2e6;
+
+// For specific devices, set RF bandwidth, usually same as samplerate
+//rx.setRxBandwidth(2e6);
+var sdr_bandwidth=2e6;
+
+
+// Define computer hostname
+var hostname="DragonOS";
+
+
+// Define SoapySDR driver name
+var sdr_device='driver=rtlsdr';  
+
+// define default rx_gain
+var rx_gain=45;
+
+// GQRX remote_control
+var gqrx_host='127.0.0.1';
+var gqrx_port=7356;
+
+// MQTT server
+var mqtt_server='127.0.0.1';
+
+
+// InfluxDB/Grafana
+var db_server='127.0.0.1:8086';
+
+
+// Destination folder, add trailing slash, can be empty
+var dest_folder='/tmp/';
+
+
+var default_freq = 100.35;
+
+
+// Define GNUplot path
+var gnuplot_app='/usr/bin/gnuplot';
+
+// SAT - Observer
+var observer_lat=44;
+var observer_lon=-1.2;
+var observer_alt=60;

--- a/RX/spectrum/1_wide_spectrum/settings.js
+++ b/RX/spectrum/1_wide_spectrum/settings.js
@@ -1,0 +1,44 @@
+// sample rate
+var sample_rate=2e6;
+
+// For specific devices, set RF bandwidth, usually same as samplerate
+//rx.setRxBandwidth(2e6);
+var sdr_bandwidth=2e6;
+
+
+// Define computer hostname
+var hostname="DragonOS";
+
+
+// Define SoapySDR driver name
+var sdr_device='driver=rtlsdr';  
+
+// define default rx_gain
+var rx_gain=45;
+
+// GQRX remote_control
+var gqrx_host='127.0.0.1';
+var gqrx_port=7356;
+
+// MQTT server
+var mqtt_server='127.0.0.1';
+
+
+// InfluxDB/Grafana
+var db_server='127.0.0.1:8086';
+
+
+// Destination folder, add trailing slash, can be empty
+var dest_folder='/tmp/';
+
+
+var default_freq = 100.35;
+
+
+// Define GNUplot path
+var gnuplot_app='/usr/bin/gnuplot';
+
+// SAT - Observer
+var observer_lat=44;
+var observer_lon=-1.2;
+var observer_alt=60;


### PR DESCRIPTION
In the base version of the decoder, a noise floor is captured in order to establish a threshold to then determine a recording window. For FM stations that are always broadcasting, the threshold never triggers. If you set a low or negative threshold, the recording never stops.